### PR TITLE
AEM 6.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-### 1.4.4
-*
+### 2.0.0
+* Enable CRXDE prior to testing CRXDE status #16 
 
 ### 1.4.3
 * Add aem get_packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.0.0
 * Enable CRXDE prior to testing CRXDE status #16 
+* Remove config runmode from config property tests
 
 ### 1.4.3
 * Add aem get_packages

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'nokogiri', '~> 1.8.1'
 gem 'nori', '~> 2.6.0'
 gem 'retries', '~> 0.0.5'
-gem 'swagger_aem', '~> 2.0.0.beta.3'
+gem 'swagger_aem', '~> 2.0.0'
 
 gem 'rspec', require: false
 gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'nokogiri', '~> 1.8.1'
 gem 'nori', '~> 2.6.0'
 gem 'retries', '~> 0.0.5'
-gem 'swagger_aem', '~> 1.2.1'
+gem 'swagger_aem', '~> 2.0.0.beta.3'
 
 gem 'rspec', require: false
 gem 'rubocop', require: false

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Configuration property:
 
     config_property = aem.config_property('someproperty', 'Boolean', true)
 
-    # set config property on /apps/system/config.author/somenode
+    # set config property on /apps/system/config/somenode
     result = config_property.create('author', 'somenode')
 
 Flush agent:
@@ -309,7 +309,7 @@ Any API error will be thrown as [RubyAem::Error](https://shinesolutions.github.i
 Testing
 -------
 
-Integration tests require an AEM instance with [Shine Solutions AEM Health Check](https://github.com/shinesolutions/aem-healthcheck) package installed and `org.apache.sling.jcr.webdav` bundle to be running.
+Integration tests require an AEM instance with [Shine Solutions AEM Health Check](https://github.com/shinesolutions/aem-healthcheck) package installed.
 
 By default it uses AEM running on http://localhost:4502 with `admin` username and `admin` password. AEM instance parameters can be configured using environment variables `aem_protocol`, `aem_host`, `aem_port`, `aem_username`, `aem_password`, and `aem_debug`.
 

--- a/ruby_aem.gemspec
+++ b/ruby_aem.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'ruby_aem'
-  s.version           = '1.4.4'
+  s.version           = '2.0.0'
   s.platform          = Gem::Platform::RUBY
   s.authors           = ['Shine Solutions', 'Cliffano Subagio']
   s.email             = ['opensource@shinesolutions.com', 'cliffano@gmail.com']
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '~> 1.8.1'
   s.add_runtime_dependency 'nori', '~> 2.6.0'
   s.add_runtime_dependency 'retries', '~> 0.0.5'
-  s.add_runtime_dependency 'swagger_aem', '~> 1.2.1'
+  s.add_runtime_dependency 'swagger_aem', '~> 2.0.0'
 
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'yard', '~> 0.9.11'

--- a/test/integration/aem_spec.rb
+++ b/test/integration/aem_spec.rb
@@ -34,6 +34,25 @@ describe 'Aem' do
 
   describe 'test get_crxde_status' do
     it 'should contain readyness indicator' do
+
+      # ensure CRXDE is enabled
+      # vanilla installation of AEM 6.3 and prior defaults to CRXDE enabled
+      # vanilla installation of AEM 6.4 defaults to CRXDE disabled
+      node = @aem.node('/apps/system/config', 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet')
+      node.delete unless node.exists.data == false
+      result = node.exists
+      expect(result.data).to eq(false)
+      node.create('sling:OsgiConfig')
+
+      config_property = @aem.config_property('alias', 'String', '/crx/server')
+      result = config_property.create('author', 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet')
+      expect(result.message).to eq('Set author org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet config String property alias=/crx/server')
+
+      config_property = @aem.config_property('dav.create-absolute-uri', 'Boolean', true)
+      result = config_property.create('author', 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet')
+      expect(result.message).to eq('Set author org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet config Boolean property dav.create-absolute-uri=true')
+
+      # check CRXDE status enabled
       aem = @aem.aem
       result = aem.get_crxde_status
       expect(result.data).to eq(true)

--- a/test/integration/aem_spec.rb
+++ b/test/integration/aem_spec.rb
@@ -34,7 +34,6 @@ describe 'Aem' do
 
   describe 'test get_crxde_status' do
     it 'should contain readyness indicator' do
-
       # ensure CRXDE is enabled
       # vanilla installation of AEM 6.3 and prior defaults to CRXDE enabled
       # vanilla installation of AEM 6.4 defaults to CRXDE disabled

--- a/test/integration/config_property_spec.rb
+++ b/test/integration/config_property_spec.rb
@@ -14,26 +14,26 @@ describe 'ConfigProperty' do
       config_property.create('author', 'org.apache.felix.http')
     end
 
-    # it 'should create Apache Felix Jetty Based HTTP Service config property correctly when node exists' do
-    #   # ensure node is created new
-    #   node = @aem.node('/apps/system/config.author', 'org.apache.felix.http')
-    #   if node.exists.data == true
-    #     node.delete
-    #   end
-    #   result = node.exists
-    #   expect(result.data).to eq(false)
-    #   result = node.create('sling:OsgiConfig')
-    #
-    #   config_property = @aem.config_property('org.apache.felix.https.enable', 'Boolean', true)
-    #   result = config_property.create('author', 'org.apache.felix.http')
-    #   expect(result.message).to eq('Set author org.apache.felix.http config Boolean property org.apache.felix.https.enable=true')
-    #
-    #   # wait until Jetty finishes restart following org.apache.felix.http config change
-    #   aem = @aem.aem
-    #   result = aem.get_login_page_wait_until_ready
-    #   expect(result.message).to eq('Login page retrieved')
-    #   expect(result.response.body).to include('QUICKSTART_HOMEPAGE')
-    # end
+    it 'should create Apache Felix Jetty Based HTTP Service config property correctly when node exists' do
+      # ensure node is created new
+      node = @aem.node('/apps/system/config', 'org.apache.felix.http')
+      if node.exists.data == true
+        node.delete
+      end
+      result = node.exists
+      expect(result.data).to eq(false)
+      result = node.create('sling:OsgiConfig')
+
+      config_property = @aem.config_property('org.apache.felix.https.enable', 'Boolean', true)
+      result = config_property.create('author', 'org.apache.felix.http')
+      expect(result.message).to eq('Set author org.apache.felix.http config Boolean property org.apache.felix.https.enable=true')
+
+      # wait until Jetty finishes restart following org.apache.felix.http config change
+      aem = @aem.aem
+      result = aem.get_login_page_wait_until_ready
+      expect(result.message).to eq('Login page retrieved')
+      expect(result.response.body).to include('QUICKSTART_HOMEPAGE')
+    end
 
     it 'should create AEM Password Reset Activator config property correctly when node exists' do
       # ensure node is created new

--- a/test/integration/config_property_spec.rb
+++ b/test/integration/config_property_spec.rb
@@ -37,7 +37,7 @@ describe 'ConfigProperty' do
 
     it 'should create AEM Password Reset Activator config property correctly when node exists' do
       # ensure node is created new
-      node = @aem.node('/apps/system/config.author', 'com.shinesolutions.aem.passwordreset.Activator')
+      node = @aem.node('/apps/system/config', 'com.shinesolutions.aem.passwordreset.Activator')
       node.delete unless node.exists.data == false
       result = node.exists
       expect(result.data).to eq(false)
@@ -50,7 +50,7 @@ describe 'ConfigProperty' do
 
     it 'should create AEM Health Check Servlet config property correctly when node exists' do
       # ensure node is created new
-      node = @aem.node('/apps/system/config.author', 'com.shinesolutions.healthcheck.hc.impl.ActiveBundleHealthCheck')
+      node = @aem.node('/apps/system/config', 'com.shinesolutions.healthcheck.hc.impl.ActiveBundleHealthCheck')
       node.delete unless node.exists.data == false
       result = node.exists
       expect(result.data).to eq(false)

--- a/test/integration/config_property_spec.rb
+++ b/test/integration/config_property_spec.rb
@@ -17,12 +17,10 @@ describe 'ConfigProperty' do
     it 'should create Apache Felix Jetty Based HTTP Service config property correctly when node exists' do
       # ensure node is created new
       node = @aem.node('/apps/system/config', 'org.apache.felix.http')
-      if node.exists.data == true
-        node.delete
-      end
+      node.delete unless node.exists.data == false
       result = node.exists
       expect(result.data).to eq(false)
-      result = node.create('sling:OsgiConfig')
+      node.create('sling:OsgiConfig')
 
       config_property = @aem.config_property('org.apache.felix.https.enable', 'Boolean', true)
       result = config_property.create('author', 'org.apache.felix.http')


### PR DESCRIPTION
Upgrade swagger_aem to 2.0.0 for AEM 6.4 config path change.
Improve integration testing to handle AEM 6.4 default where CRXDE is disabled by default.