### PR TITLE
Extending agent opts

### DIFF
--- a/conf/spec.yaml
+++ b/conf/spec.yaml
@@ -322,7 +322,9 @@ flushagent:
           jcrcontentslingresource_type: cq/replication/components/agent
           jcrcontenttransport_uri: '%{dest_base_url}/dispatcher/invalidate.cache'
           jcrcontentlog_level: '%{log_level}'
-          jcrcontentno_versioning: true
+          jcrcontentno_status_update: '%{no_status_update}'
+          jcrcontentno_versioning: '%{no_versioning}'
+          jcrcontentprotocol_http_expired: '%{http_expired}'
           jcrcontentprotocol_http_headers:
             - 'CQ-Action:{action}'
             - 'CQ-Handle:{path}'
@@ -330,12 +332,17 @@ flushagent:
           jcrcontentprotocol_http_headers_type_hint: String[]
           jcrcontentprotocol_http_method: GET
           jcrcontentretry_delay: '%{retry_delay}'
+          jcrcontentreverse_replication: '%{reverse_replication}'
           jcrcontentserialization_type: flush
           jcrcontentjcrmixin_types: cq:ReplicationStatus
-          jcrcontenttrigger_receive: true
-          jcrcontenttrigger_specific: true
+          jcrcontenttrigger_distribute: '%{distribute}'
+          jcrcontenttrigger_modified: '%{modified}'
+          jcrcontenttrigger_on_off_time: '%{on_off_time}'
+          jcrcontenttrigger_receive: '%{receive}'
+          jcrcontenttrigger_specific: '%{specific}'
+          jcrcontentuser_id: '%{agent_user_id}'
           jcrcontentcqtemplate: /libs/cq/replication/templates/agent
-          jcrcontentenabled: true
+          jcrcontentenabled: '%{enabled}'
           jcrcontentssl: '%{ssl}'
       responses:
         200:
@@ -932,8 +939,11 @@ replicationagent:
           jcrcontenttransport_password: '%{transport_password}'
           jcrcontentlog_level: '%{log_level}'
           jcrcontentretry_delay: '%{retry_delay}'
+          jcrcontentuser_id: '%{user_id}'
           jcrcontentcqtemplate: /libs/cq/replication/templates/agent
-          jcrcontentenabled: true
+          jcrcontentenabled: '%{enabled}'
+          jcrcontentssl: '%{ssl}'
+          jcrcontentprotocol_http_expired: '%{http_expired}'
       responses:
         200:
           handler: simple

--- a/lib/ruby_aem/resources/flush_agent.rb
+++ b/lib/ruby_aem/resources/flush_agent.rb
@@ -60,7 +60,7 @@ module RubyAem
         opts = {
           enabled: true,
           serialization_type: 'flush',
-          retry_delay: 30_000,
+          retry_delay: 30_000
           agent_user_id: nil,
           log_level: 'error',
           reverse_replication: false,

--- a/lib/ruby_aem/resources/flush_agent.rb
+++ b/lib/ruby_aem/resources/flush_agent.rb
@@ -37,16 +37,42 @@ module RubyAem
       # @param description flush agent description
       # @param dest_base_url base URL of the agent target destination, e.g. http://somedispatcher:8080
       # @param opts optional parameters:
-      # - log_level: error, info, debug, default is error
+      # - enabled: default is true
+      # - flush_serialization_type: default is flush
       # - retry_delay: in milliseconds, default is 30_000
+      # - agent_user_id: default is nil
+      # - log_level: error, info, debug, default is error
+      # - reverse_replication: default is false
+      # - ssl: Default, Relaxed, Client Auth, default is nil
+      # - https_expired: default is false
+      # - specific: default is true
+      # - modified: default is false
+      # - distribute: default is false
+      # - on_off_time: default is false
+      # - receive: default is false
+      # - no_status_update: default is true
+      # - no_versioning: default is true
       # @return RubyAem::Result
       def create_update(
         title,
         description,
         dest_base_url,
         opts = {
+          enabled: true,
+          serialization_type: 'flush',
+          retry_delay: 30_000,
+          agent_user_id: nil,
           log_level: 'error',
-          retry_delay: 30_000
+          reverse_replication: false,
+          ssl: nil,
+          http_expired: false,
+          specific: true,
+          modified: false,
+          distribute: false,
+          on_off_time: false,
+          receive: false,
+          no_status_update: true,
+          no_versioning: true
         }
       )
         @call_params[:title] = title

--- a/lib/ruby_aem/resources/replication_agent.rb
+++ b/lib/ruby_aem/resources/replication_agent.rb
@@ -40,6 +40,11 @@ module RubyAem
       # - transport_password: password for transport user, default is admin
       # - log_level: error, info, debug, default is error
       # - retry_delay: in milliseconds, default is 30_000
+      # - serialization_type: default is durbo
+      # - user_id: default is nil
+      # - enabled: default is true
+      # - ssl: default is nil
+      # - http_expired: default is nil
       # @return RubyAem::Result
       def create_update(
         title,
@@ -49,12 +54,21 @@ module RubyAem
           transport_user: 'admin',
           transport_password: 'admin',
           log_level: 'error',
-          retry_delay: 30_000
+          retry_delay: 30_000,
+          serialization_type: 'durbo',
+          user_id: nil,
+          enabled: true,
+          ssl: nil,
+          http_expired: nil
         }
       )
         @call_params[:title] = title
         @call_params[:description] = description
         @call_params[:dest_base_url] = dest_base_url
+
+        uri = URI.parse(dest_base_url)
+        @call_params[:ssl] = uri.scheme == 'https' ? 'relaxed' : ''
+
         @call_params = @call_params.merge(opts)
         @client.call(self.class, __callee__.to_s, @call_params)
       end

--- a/lib/ruby_aem/resources/replication_agent.rb
+++ b/lib/ruby_aem/resources/replication_agent.rb
@@ -54,7 +54,7 @@ module RubyAem
           transport_user: 'admin',
           transport_password: 'admin',
           log_level: 'error',
-          retry_delay: 30_000,
+          retry_delay: 30_000
           serialization_type: 'durbo',
           user_id: nil,
           enabled: true,
@@ -65,9 +65,6 @@ module RubyAem
         @call_params[:title] = title
         @call_params[:description] = description
         @call_params[:dest_base_url] = dest_base_url
-
-        uri = URI.parse(dest_base_url)
-        @call_params[:ssl] = uri.scheme == 'https' ? 'relaxed' : ''
 
         @call_params = @call_params.merge(opts)
         @client.call(self.class, __callee__.to_s, @call_params)


### PR DESCRIPTION
Changed some default values to variables in conf/spec.yaml; added some additional flush and replication agent values that are needed to configure other opts to be used in Chef resources. Please review and let me know what you think of these proposed changes/additions. Thanks!