### PR TITLE
Update resource `config_property` #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Upgrade swagger_aem to 3.2.0
+
 ## 3.4.0 - 2019-08-22
 ### Added
 - Add new dependency swagger_aem_osgi 1.1.0 to gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Update resource `config_property` to allow the configuration of all OSGI configuration nodes #31
 - Upgrade swagger_aem to 3.2.0
 
 ## 3.4.0 - 2019-08-22

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'openssl', '2.1.2'
 gem 'retries', '0.0.5'
-gem 'swagger_aem', '3.1.0'
+gem 'swagger_aem', '3.2.0'
 gem 'swagger_aem_osgi', '1.0.0'
 
 gem 'rspec', '3.8.0', require: false

--- a/conf/spec.yaml
+++ b/conf/spec.yaml
@@ -721,6 +721,21 @@ path:
           message: 'Path %{path} deleted'
 configproperty:
   actions:
+    create:
+      api: sling
+      operation: postConfigProperty
+      params:
+        required:
+          config_node_name: '%{config_node_name}'
+        optional:
+          - query_params
+      responses:
+        200:
+          handler: simple
+          message: 'Set %{config_node_name} config %{type} property %{name}=%{value}'
+        201:
+          handler: simple
+          message: 'Set %{config_node_name} config %{type} property %{name}=%{value}'
     createapachefelixjettybasedhttpservice:
       api: sling
       operation: postConfigApacheFelixJettyBasedHttpService

--- a/lib/ruby_aem/resources/config_property.rb
+++ b/lib/ruby_aem/resources/config_property.rb
@@ -29,8 +29,11 @@ module RubyAem
         @call_params = {
           name: name,
           type: type,
-          value: value
+          value: value,
+          query_params: {}
         }
+        @call_params[:query_params][@call_params[:name]] = @call_params[:value]
+        @call_params[:query_params]["#{@call_params[:name]}@TypeHint"] = @call_params[:type]
       end
 
       # Create a new config property.
@@ -38,15 +41,8 @@ module RubyAem
       # @param config_node_name the node name of a given OSGI config
       # @return RubyAem::Result
       def create(config_node_name)
-        name = RubyAem::Swagger.property_to_parameter(@call_params[:name])
-        type_hint_prefix = name.gsub(/^_/, '')
-
         @call_params[:config_node_name] = config_node_name
-        @call_params[name.to_sym] = @call_params[:value]
-        @call_params["#{type_hint_prefix}_type_hint".to_sym] = @call_params[:type]
-
-        config_name = Swagger.config_node_name_to_config_name(config_node_name)
-        @client.call(self.class, __callee__.to_s.concat(config_name.downcase.gsub(/\s+/, '')), @call_params)
+        @client.call(self.class, __callee__.to_s, @call_params)
       end
     end
   end

--- a/ruby_aem.gemspec
+++ b/ruby_aem.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ['lib']
 
   s.add_runtime_dependency 'retries', '0.0.5'
-  s.add_runtime_dependency 'swagger_aem', '3.1.0'
+  s.add_runtime_dependency 'swagger_aem', '3.2.0'
   s.add_runtime_dependency 'swagger_aem_osgi', '1.0.0'
 
   s.add_development_dependency 'rspec', '3.8.0'

--- a/test/unit/resources/aem_spec.rb
+++ b/test/unit/resources/aem_spec.rb
@@ -204,7 +204,7 @@ describe 'Aem' do
       mock_error = RubyAem::Error.new(mock_message_error, mock_result_error)
 
       mock_message_not_finished = 'Install status retrieved'
-      status_not_finished = SwaggerAemClient::InstallStatusStatus.new(finished: false, itemCount: 123)
+      status_not_finished = SwaggerAemClient::InstallStatusStatus.new(finished: false, item_count: 123)
       mock_body_not_finished = SwaggerAemClient::InstallStatus.new(status: status_not_finished)
       mock_response_not_finished = double('mock_response_not_finished')
       mock_result_not_finished = double('mock_result_not_finished')
@@ -213,7 +213,7 @@ describe 'Aem' do
       expect(mock_result_not_finished).to receive(:message).twice.and_return(mock_message_not_finished)
 
       mock_message_finished = 'Install status retrieved'
-      status_finished = SwaggerAemClient::InstallStatusStatus.new(finished: true, itemCount: 0)
+      status_finished = SwaggerAemClient::InstallStatusStatus.new(finished: true, item_count: 0)
       mock_body_finished = SwaggerAemClient::InstallStatus.new(status: status_finished)
       mock_response_finished = double('mock_response_finished')
       mock_result_finished = double('mock_result_finished')

--- a/test/unit/resources/config_property_spec.rb
+++ b/test/unit/resources/config_property_spec.rb
@@ -13,46 +13,16 @@ describe 'ConfigProperty' do
     it 'should call client with expected parameters' do
       expect(@mock_client).to receive(:call).once.with(
         RubyAem::Resources::ConfigProperty,
-        'createapachefelixjettybasedhttpservice',
+        'create',
         name: 'someproperty',
         config_node_name: 'org.apache.felix.http',
         type: 'Boolean',
         value: 'true',
-        someproperty: 'true',
-        someproperty_type_hint: 'Boolean'
+        query_params: { 'someproperty' => 'true',
+                        'someproperty@TypeHint' => 'Boolean' }
       )
       config_property = RubyAem::Resources::ConfigProperty.new(@mock_client, 'someproperty', 'Boolean', 'true')
       config_property.create('org.apache.felix.http')
-    end
-
-    it 'should call client with expected parameters when property is a keyword' do
-      expect(@mock_client).to receive(:call).once.with(
-        RubyAem::Resources::ConfigProperty,
-        'createapacheslingdavexservlet',
-        name: 'alias',
-        config_node_name: 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet',
-        type: 'String',
-        value: '/crx/server',
-        _alias: '/crx/server',
-        alias_type_hint: 'String'
-      )
-      config_property = RubyAem::Resources::ConfigProperty.new(@mock_client, 'alias', 'String', '/crx/server')
-      config_property.create('org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet')
-    end
-
-    it 'should call client with expected parameters when property is a keyword for org.apache.http.proxyconfigurator.config' do
-      expect(@mock_client).to receive(:call).once.with(
-        RubyAem::Resources::ConfigProperty,
-        'createapachehttpcomponentsproxyconfiguration',
-        name: 'proxy_host',
-        config_node_name: 'org.apache.http.proxyconfigurator.config',
-        type: 'String',
-        value: '192.168.1.1',
-        proxy_host: '192.168.1.1',
-        proxy_host_type_hint: 'String'
-      )
-      config_property = RubyAem::Resources::ConfigProperty.new(@mock_client, 'proxy_host', 'String', '192.168.1.1')
-      config_property.create('org.apache.http.proxyconfigurator.config')
     end
   end
 end


### PR DESCRIPTION
This PR will update the ruby_aem resource `config_property` to allow the user to set the configuration properties of all available OSGI configuration nodes at `/apps/system/config/{configNodeName}`.

The resource `config_property` accepts the same input parameters as before, therefore it's backward compatible. Though, as the destination it uses the new API call introduced to [swagger_aem](https://github.com/shinesolutions/swagger-aem/pull/52). 

### Changed
- Update resource `config_property` to allow the configuration of all 
OSGI configuration nodes #31