### PR TITLE
Feature/add support for alias update for flush agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added the possibility to configure the aliasUpdate for a replication flush agent.
 
 ## 3.17.0 - 2024-07-29
 ### Added

--- a/conf/spec.yaml
+++ b/conf/spec.yaml
@@ -354,6 +354,7 @@ flushagent:
           jcrcontent_jcrdescription: '%{description}'
           jcrcontent_slingresource_type: cq/replication/components/agent
           jcrcontent_transport_uri: '%{dest_base_url}/dispatcher/invalidate.cache'
+          jcrcontent_alias_update: '%{alias_update}'
           jcrcontent_log_level: '%{log_level}'
           jcrcontent_no_versioning: true
           jcrcontent_protocol_http_headers:

--- a/lib/ruby_aem/resources/flush_agent.rb
+++ b/lib/ruby_aem/resources/flush_agent.rb
@@ -37,6 +37,7 @@ module RubyAem
       # @param description flush agent description
       # @param dest_base_url base URL of the agent target destination, e.g. http://somedispatcher:8080
       # @param opts optional parameters:
+      # - alias_update: true, false, default is false
       # - log_level: error, info, debug, default is error
       # - retry_delay: in milliseconds, default is 30_000
       # @return RubyAem::Result
@@ -45,6 +46,7 @@ module RubyAem
         description,
         dest_base_url,
         opts = {
+          alias_update: false,
           log_level: 'error',
           retry_delay: 30_000
         }


### PR DESCRIPTION
Required for: https://github.com/shinesolutions/puppet-aem-resources/pull/116
Needs: https://github.com/shinesolutions/swagger-aem/pull/91 (version bump still needs to be done after a swagger-aem is being released)